### PR TITLE
사용자 정보에 userId 저장, 정보 중복 로딩 방지

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,12 +2,7 @@
 import { RouterLink, RouterView } from 'vue-router'
 import HelloWorld from './components/HelloWorld.vue'
 import { onMounted } from 'vue'
-import { retrieveUserInfoIfHasAccessToken } from './services/userService'
-
-onMounted(() => {
-  // 액세스 토큰이 있는 상태에서 최초 접속 시 사용자 정보 가져오기
-  retrieveUserInfoIfHasAccessToken()
-})
+import { retrieveUserInfoIfPossible } from './services/userService'
 </script>
 
 <template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import SearchPlanView from '@/views/search-plan/SearchPlanView.vue'
 import { useAuthStore } from '@/stores/auth'
-import { retrieveUserInfoIfHasAccessToken } from '@/services/userService'
+import { retrieveUserInfoIfPossible } from '@/services/userService'
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
@@ -34,7 +34,7 @@ const router = createRouter({
 
 router.beforeEach(async (to, from, next) => {
   // 페이지 이동 사이에 액세스 토큰이 갱신되면 사용자 정보 받아오기
-  await retrieveUserInfoIfHasAccessToken()
+  await retrieveUserInfoIfPossible()
 
   if (to.path === '/') {
     // 로그인 후 이 페이지로 리다이렉트되면 기존 페이지로 리다이렉트 처리

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -7,7 +7,7 @@ const getUserInfo = async () => {
   const response = await userApi.getUserInfo()
   return {
     userId: response.data.userId,
-    username: response.data.username,
+    nickname: response.data.nickname,
   } as UserInfo
 }
 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -6,6 +6,7 @@ import { useUserStore } from '@/stores/userStore'
 const getUserInfo = async () => {
   const response = await userApi.getUserInfo()
   return {
+    userId: response.data.userId,
     username: response.data.username,
   } as UserInfo
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -11,15 +11,20 @@ const getUserInfo = async () => {
   } as UserInfo
 }
 
-const retrieveUserInfoIfHasAccessToken = async () => {
+// 액세스 토큰이 있는데 사용자 정보가 없으면 사용자 정보를 가져옴
+const retrieveUserInfoIfPossible = async () => {
   const accessToken = getAccessToken()
   if (!accessToken) {
     return null
   }
 
-  const userInfo = await getUserInfo()
   const userStore = useUserStore()
+  if (userStore.userInfo) {
+    return
+  }
+
+  const userInfo = await getUserInfo()
   userStore.setUserInfo(userInfo)
 }
 
-export { getUserInfo, retrieveUserInfoIfHasAccessToken }
+export { getUserInfo, retrieveUserInfoIfPossible }

--- a/src/types/dto/user.ts
+++ b/src/types/dto/user.ts
@@ -1,4 +1,4 @@
 export interface UserInfoDto {
   userId: number
-  username: string
+  nickname: string
 }

--- a/src/types/dto/user.ts
+++ b/src/types/dto/user.ts
@@ -1,3 +1,4 @@
 export interface UserInfoDto {
+  userId: number
   username: string
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,3 +1,4 @@
 export interface UserInfo {
+  userId: number
   username: string
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,4 @@
 export interface UserInfo {
   userId: number
-  username: string
+  nickname: string
 }


### PR DESCRIPTION
## #️⃣ Issue Number

Resolves #27 

## 📝 요약(Summary)

- 사용자 정보에 nickname 뿐만 아니라 userId도 저장
- 앱 시작 시에 사용자 정보를 한 번만 불러오도록 수정
- 라우팅 간에는 사용자 정보가 기존에 없을 때만 불러오도록 수정
