### PR TITLE
Teleport 마운트 시점을 늦춤

### DIFF
--- a/src/views/search-plan/SearchPlanView.vue
+++ b/src/views/search-plan/SearchPlanView.vue
@@ -20,8 +20,6 @@ import AttractionInfoWindow from '@/components/map/AttractionInfoWindow.vue'
 import Pagination from '@/components/Pagination.vue'
 import EditableLabel from '@/components/EditableLabel.vue'
 import PointList from '@/components/plan/PointList.vue'
-import MockProfileIcon from '@/components/plan/MockProfileIcon.vue'
-import PlanWizardModal from '@/components/plan/PlanWizardModal.vue'
 import {
   ref,
   reactive,
@@ -257,6 +255,8 @@ watch(
   },
   { immediate: true },
 )
+
+const canSearchCardTeleport = ref(false)
 
 const searchCardTarget = computed(() => {
   if (mode.value !== 'plan') {
@@ -683,6 +683,11 @@ onMounted(() => {
 
   updateMobileMode()
   window.addEventListener('resize', updateMobileMode)
+
+  // DOM이 준비된 후에 teleport 가능하도록 설정
+  nextTick(() => {
+    canSearchCardTeleport.value = true
+  })
 })
 
 onUnmounted(() => {
@@ -1012,7 +1017,7 @@ onUnmounted(() => {
       </aside>
     </div>
   </div>
-  <Teleport :to="searchCardTarget">
+  <Teleport v-if="canSearchCardTeleport" :to="searchCardTarget">
     <div class="contents">
       <div class="tour-search">
         <div class="search-form">


### PR DESCRIPTION
## #️⃣ Issue Number

Resolves #22 

## 📝 요약(Summary)

`Teleport` 마운트 시점을 한 번 컴포넌트가 마운트 완료된 시점 이후로 미루어 `target`이 이미 마운트되어 존재함을 보장함.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] `SearchPlanView`의 마운트 여부를 체크
- [x] 마운트 이후에 `nextTick`을 이용해 `Teleport` 마운트